### PR TITLE
rename touch coloumn for stones table, and create seeds

### DIFF
--- a/db/migrate/20210302112228_rename_touch_column_to_stones.rb
+++ b/db/migrate/20210302112228_rename_touch_column_to_stones.rb
@@ -1,0 +1,5 @@
+class RenameTouchColumnToStones < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :stones, :touch, :sensation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_01_181347) do
+ActiveRecord::Schema.define(version: 2021_03_02_112228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_181347) do
     t.float "weight"
     t.text "description"
     t.string "gender"
-    t.string "touch"
+    t.string "sensation"
     t.float "price"
     t.string "address"
     t.bigint "user_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,21 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+puts "Destroy all users and stones"
+Stone.destroy_all
+User.destroy_all
+
+puts "Create Users"
+
+User.create!(first_name: "Manon", last_name: "nonon", username: "Nionion", age:"23", phone_number:"0739403920", address:"2 Rue Polnareff, 59000 Lille", email: "mamama@gmail.com", password:"mamama")
+User.create!(first_name: "Pierre", last_name: "Quiroule", username: "Plouf", age:"35", phone_number:"0630293049", address:"54 Boulavard de la pierre", email: "papapa@gmail.com", password:"papapa")
+
+puts "Create Stones"
+
+Stone.create!(user: User.first, name:"Patrick", category:"Ruby", age:"37", weight:"2,8", gender:"no-binary", sensation:"smooth", price:"15,3", address:"3 rue du colonel Pollet, 59000 Lille")
+Stone.create!(user: User.first, name:"Cléo", category:"Basalt", age:"107", weight:"5,7", gender:"Woman", sensation:"rough", price:"1,5", address:"190 boulevard du petit poney, 62100 Calais")
+Stone.create!(user: User.last, name:"Line", category:"Emeraud", age:"59", weight:"3,6", gender:"no-binary", sensation:"smooth", price:"3,2", address:"49 avenue de l'Europe, 75000 Paris")
+Stone.create!(user: User.last, name:"Pierre", category:"Sapphir", age:"503", weight:"10,5", gender:"Man", sensation:"rough", price:"139,6", address:"405 route du tavernier, 59370 Mons-en-baroeul")
+
+puts "Finished !"


### PR DESCRIPTION
changement de nom pour la colonne "touch" de la table stones cause problème avec ActiveRecord.
Création des seeds.